### PR TITLE
Fix: Resolve Race Condition in storage_pool::activate_chunk

### DIFF
--- a/monad/category/async/storage_pool.cpp
+++ b/monad/category/async/storage_pool.cpp
@@ -829,7 +829,6 @@ storage_pool::activate_chunk(chunk_type const which, uint32_t const id)
     if (ret) {
         return ret;
     }
-    g.unlock();
     auto &chunkinfo = chunks_[which][id];
     switch (which) {
     case chunk_type::cnv:


### PR DESCRIPTION
This commit addresses a critical race condition in the storage_pool::activate_chunk function.

The original implementation prematurely released a mutex lock (g.unlock()) before completing the operation. This created a window where a concurrent thread could modify the shared chunks_ vector, leading to a potential use-after-free vulnerability. Using a dangling pointer to a freed chunk could result in a crash or, more severely, be exploited for arbitrary code execution.

The fix removes the explicit g.unlock() call. The code now relies on the RAII (Resource Acquisition Is Initialization) principle, where the std::unique_lock object g will automatically release the lock when it goes out of scope. This guarantees that the entire read-and-modify operation on the shared resource is atomic and protected, eliminating the race condition.