### PR TITLE
Fix build scripts and refactor statesync FFI

### DIFF
--- a/bft/monad-event-ring/build.rs
+++ b/bft/monad-event-ring/build.rs
@@ -48,10 +48,8 @@ fn main() {
 
     let mut builder = bindgen::Builder::default()
         .header("wrapper.h")
-        .clang_args(["-x", "c", "-std=c23"])
+        .clang_args(["-x", "c++", "-std=c++20"])
         .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
-        .wrap_static_fns(true)
-        .wrap_static_fns_path(out_dir.join(STATIC_FNS_PATH))
         .derive_copy(true)
         .derive_debug(true)
         .derive_partialeq(true)
@@ -75,16 +73,4 @@ fn main() {
         .replace(r#"#[doc = " "#, r#"#[doc = ""#);
 
     std::fs::write(out_dir.join("bindings.rs"), bindings_str).expect("Couldn't write bindings!");
-
-    cc::Build::new()
-        .std("c2x")
-        .file(out_dir.join(format!("{STATIC_FNS_PATH}.c")))
-        .includes(
-            std::iter::once(PathBuf::from(env!("CARGO_MANIFEST_DIR"))).chain(
-                INCLUDES
-                    .iter()
-                    .map(|(include_path, _)| PathBuf::from(include_path)),
-            ),
-        )
-        .compile(STATIC_FNS_PATH);
 }

--- a/bft/monad-exec-events/build.rs
+++ b/bft/monad-exec-events/build.rs
@@ -38,8 +38,7 @@ fn main() {
     let out_dir = PathBuf::from(std::env::var("OUT_DIR").unwrap());
 
     let mut builder = bindgen::Builder::default()
-        .header("wrapper.h")
-        .clang_args(["-x", "c", "-std=c23"])
+        .clang_args(["-x", "c++", "-std=c++20"])
         .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
         .derive_copy(true)
         .derive_debug(true)
@@ -56,7 +55,8 @@ fn main() {
         builder = builder.clang_arg(format!("-I{lib_path}"));
 
         for lib_file in lib_files.iter() {
-            builder = builder.allowlist_file(format!("{lib_path}{lib_file}"));
+            let path = format!("{lib_path}{lib_file}");
+            builder = builder.header(path.clone()).allowlist_file(path);
         }
     }
 


### PR DESCRIPTION
This change addresses build failures and improves the robustness of the state synchronization FFI layer between the Rust and C++ components.

The build scripts for `monad-event-ring` and `monad-exec-events` were incorrectly configured to parse C++ headers as C, causing build failures. These scripts have been corrected to use the C++ language standard.

The `monad-statesync` FFI has been refactored to:
- Replace `assert!` macros and panics with explicit error handling and logging, making the node more resilient.
- Rename confusingly named enums for better code clarity (`SyncRequest` -> `StateSyncCommand`, `SyncResponse` -> `StateSyncEvent`).